### PR TITLE
Add validation `id` output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -6,5 +6,5 @@ output "certificate_arn" {
 
 output "validation_id" {
   description = "The time at which the certificate was issued"
-  value       = aws_acm_certificate_validation.this.id
+  value       = one(aws_acm_certificate_validation.this).id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,3 +3,8 @@ output "certificate_arn" {
   description = "The ARN of the AWS ACM Certificate this created"
   value       = aws_acm_certificate.this.arn
 }
+
+output "validation_id" {
+  description = "The time at which the certificate was issued"
+  value       = aws_acm_certificate_validation.this.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,5 +6,5 @@ output "certificate_arn" {
 
 output "validation_id" {
   description = "The time at which the certificate was issued"
-  value       = one(aws_acm_certificate_validation.this).id
+  value       = var.create_dns_validation ? one(aws_acm_certificate_validation.this).id : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,5 +6,5 @@ output "certificate_arn" {
 
 output "validation_id" {
   description = "The time at which the certificate was issued"
-  value       = var.create_dns_validation ? one(aws_acm_certificate_validation.this).id : null
+  value       = one(aws_acm_certificate_validation.this[*].id)
 }


### PR DESCRIPTION
### Added
- Add an output that might help us wait for certificate validation
  * Attribute documentation is [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation#id).