### PR TITLE
Release 0.2.0 - Add `validation_id` output, use Ubuntu 22.04 for test

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   terraform:
     name: 'Terraform'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,5 +6,5 @@ output "certificate_arn" {
 
 output "validation_id" {
   description = "The time at which the certificate was issued"
-  value       = aws_acm_certificate_validation.this.id
+  value       = one(aws_acm_certificate_validation.this).id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,3 +3,8 @@ output "certificate_arn" {
   description = "The ARN of the AWS ACM Certificate this created"
   value       = aws_acm_certificate.this.arn
 }
+
+output "validation_id" {
+  description = "The time at which the certificate was issued"
+  value       = aws_acm_certificate_validation.this.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,5 +6,5 @@ output "certificate_arn" {
 
 output "validation_id" {
   description = "The time at which the certificate was issued"
-  value       = one(aws_acm_certificate_validation.this).id
+  value       = var.create_dns_validation ? one(aws_acm_certificate_validation.this).id : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,5 +6,5 @@ output "certificate_arn" {
 
 output "validation_id" {
   description = "The time at which the certificate was issued"
-  value       = var.create_dns_validation ? one(aws_acm_certificate_validation.this).id : null
+  value       = one(aws_acm_certificate_validation.this[*].id)
 }


### PR DESCRIPTION
### Fixed
- Specify at least a major version of Ubuntu (used for running test in GitHub Actions)

### Added
- Add a `validation_id` output that might help enable us wait for certificate validation