### PR TITLE
Wait for certificate validation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,6 @@ resource "cloudflare_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  count                   = var.create_dns_validation ? 1 : 0
   certificate_arn         = aws_acm_certificate.this.arn
   validation_record_fqdns = [cloudflare_record.validation[0].hostname]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,5 +6,5 @@ output "certificate_arn" {
 
 output "validation_id" {
   description = "The time at which the certificate was issued"
-  value       = one(aws_acm_certificate_validation.this[*].id)
+  value       = aws_acm_certificate_validation.this.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 
 output "certificate_arn" {
-  description = "The ARN of the AWS ACM Certificate this created"
-  value       = aws_acm_certificate.this.arn
+  description = "The ARN of the (validated) AWS ACM Certificate this created"
+  value       = aws_acm_certificate_validation.this.certificate_arn
 }
 
 output "validation_id" {


### PR DESCRIPTION
### Fixed
- Always have an `aws_acm_certificate_validation` resource 
  * This is how we can depend on / know when the certificate has been validated and issued.
- Get the certificate ARN from the validation resource 
  * The validation resource's certificate ARN is available once the certificate has been issued:
    > The aws_api_gateway_domain_name resource expects dependency on the aws_acm_certificate_validation as only verified certificates can be used. This can be made either explicitly by adding the depends_on = [aws_acm_certificate_validation.cert] attribute. Or implicitly by referring certificate ARN from the validation resource where it will be available after the resource creation: regional_certificate_arn = aws_acm_certificate_validation.cert.certificate_arn.
    > ([source](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/api_gateway_domain_name#argument-reference))
  * Note that we are using `this` as the resource name, rather than `cert` as used in that documentation snippet.