### PR TITLE
When validating certificate, do not assume this code created the DNS record (since it is optional)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,5 @@ resource "cloudflare_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  certificate_arn         = aws_acm_certificate.this.arn
-  validation_record_fqdns = [cloudflare_record.validation[0].hostname]
+  certificate_arn = aws_acm_certificate.this.arn
 }


### PR DESCRIPTION
### Fixed
- When validating certificate, do not assume this code created the DNS record (since it is optional)

---

The validation_record_fqdns attribute [is optional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation.html#validation_record_fqdns), and it looks like this will still work fine without it.